### PR TITLE
Calculate spot/pixel distances from the stimulus

### DIFF
--- a/src/CounterMarking.jl
+++ b/src/CounterMarking.jl
@@ -17,9 +17,11 @@ using Statistics
 export segment_image, stimulus_index, spots, Spot, upperleft
 export writexlsx, process_images, density_map
 export randshow, meanshow, gui
+export spot_distances, pixel_distances
 
 include("segment.jl")
 include("xlxs.jl")
 include("gui.jl")
+include("distances.jl")
 
 end

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -1,0 +1,21 @@
+# pixel distance for each spot
+function spot_distances(spot_dict, stimulus)
+    origin = stimulus[2].centroid
+    dist_dict = Dict{Int,Float64}()
+    for (i,s) in spot_dict
+        push!(dist_dict, i => sqrt(sum(abs2, s.centroid .- origin)))
+    end
+    return dist_dict
+end
+
+# pixel distance for each pixel belonging to a mark
+function pixel_distances(indexmap, stimulus)
+    origin = stimulus[2].centroid
+    distances = Float64[]
+    for c in CartesianIndices(indexmap)
+        if indexmap[c] != 0 && indexmap[c] != stimulus[1]
+            push!(distances, sqrt(sum(abs2, Tuple(c) .- origin)))
+        end
+    end
+    return sort(distances)
+end

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -1,21 +1,21 @@
 # pixel distance for each spot
 function spot_distances(spot_dict, stimulus)
     origin = stimulus[2].centroid
-    dist_dict = Dict{Int,Float64}()
+    dists = Float64[]
     for (i,s) in spot_dict
-        push!(dist_dict, i => sqrt(sum(abs2, s.centroid .- origin)))
+        push!(dists, sqrt(sum(abs2, s.centroid .- origin)))
     end
-    return dist_dict
+    return sort(dists)
 end
 
 # pixel distance for each pixel belonging to a mark
 function pixel_distances(indexmap, stimulus)
     origin = stimulus[2].centroid
-    distances = Float64[]
+    dists = Float64[]
     for c in CartesianIndices(indexmap)
         if indexmap[c] != 0 && indexmap[c] != stimulus[1]
-            push!(distances, sqrt(sum(abs2, Tuple(c) .- origin)))
+            push!(dists, sqrt(sum(abs2, Tuple(c) .- origin)))
         end
     end
-    return sort(distances)
+    return sort(dists)
 end

--- a/src/segment.jl
+++ b/src/segment.jl
@@ -121,25 +121,43 @@ function spots(
             stimulus[] = key => Spot(val[3], (round(Int, val[1] / val[3]), round(Int, val[2] / val[3])))
             return false
         end
-        val[3] <= max_size_frac * length(seg.image_indexmap) || return false
+        return val[3] <= max_size_frac * length(seg.image_indexmap)
         # # is the centroid within the segment?
         # x, y = round(Int, val[1] / val[3]), round(Int, val[2] / val[3])
         # l = seg.image_indexmap[x, y]
         # @show l
         # l == key || return false
         # is the segment lighter than most of its neighbors?
-        dcol, ncol = zero(valtype(seg.segment_means)), 0
-        for (k, n) in nadj
-            if key == k[1] || key == k[2]
-                l1, l2 = k[1], k[2]
-                if l1 == key
-                    l1, l2 = l2, l1
-                end
-                dcol += n * (segment_mean(seg, l1) - segment_mean(seg, l2))
-                ncol += n
-            end
+        # dcol, ncol = zero(valtype(seg.segment_means)), 0
+        # for (k, n) in nadj
+        #     if key == k[1] || key == k[2]
+        #         l1, l2 = k[1], k[2]
+        #         if l1 == key
+        #             l1, l2 = l2, l1
+        #         end
+        #         dcol += n * (segment_mean(seg, l1) - segment_mean(seg, l2))
+        #         ncol += n
+        #     end
+        # end
+        # return reducec(+, dcol) < 0
+    end
+    return Dict(l => Spot(val[3], (round(Int, val[1] / val[3]), round(Int, val[2] / val[3]))) for (l, val) in centroidsacc), stimulus[]
+end
+
+function spots(
+        indexmap::Matrix{Int},
+        istim::Int;
+        max_size_frac=0.1, 
+        kwargs...
+    )
+    centroidsacc, nadj = get_centroidsacc(indexmap)
+    stimulus = Ref{Pair{Int,Spot}}()
+    filter!(centroidsacc) do (key, val)
+        if key == istim
+            stimulus[] = key => Spot(val[3], (round(Int, val[1] / val[3]), round(Int, val[2] / val[3])))
+            return false
         end
-        return reducec(+, dcol) < 0
+        return val[3] <= max_size_frac * length(indexmap)
     end
     return Dict(l => Spot(val[3], (round(Int, val[1] / val[3]), round(Int, val[2] / val[3]))) for (l, val) in centroidsacc), stimulus[]
 end


### PR DESCRIPTION
Adds `spot_distances()` and `pixel_distances()`, which calculate the distance in pixels from the centroid of the stimulus for all segmented spots or pixels, respectively. 